### PR TITLE
Update rclone_upload

### DIFF
--- a/rclone_upload
+++ b/rclone_upload
@@ -123,15 +123,6 @@ else
 	ServiceAccount=""
 fi
 
-# Adjusting service_account_file if using Service Accounts
-if [[ $UseServiceAccountUpload == 'Y' ]]; then
-	ServiceAccountFile+=$CounterNumber.json
-	rclone config update $ServiceAccountRemote service_account_file $ServiceAccountDirectory/$ServiceAccountFile
-	echo "$(date "+%d.%m.%Y %T") INFO: Adjusted service_account_file for upload remote ${RcloneUploadRemoteName} to ${ServiceAccountFile} based on counter ${CounterNumber}."
-else
-	echo "$(date "+%d.%m.%Y %T") INFO: Uploading using upload remote ${RcloneUploadRemoteName}"
-fi
-
 #######  Upload files  ##########
 
 # Check bind option


### PR DESCRIPTION
Cleanup: Removed Un-needed code. 
No need to set the service account in the rclone config since it will be referenced and set during the rclone move phase.