### PR TITLE
Changes to handle remnant/hanging counter_x, counter_y

### DIFF
--- a/rclone_upload
+++ b/rclone_upload
@@ -193,11 +193,11 @@ fi
 # update counter and remove other control files
 if [[  $UseServiceAccountUpload == 'Y' ]]; then
 	if [[ "$CounterNumber" == "$CountServiceAccounts" ]];then
-		rm /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_$CounterNumber
+		rm /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_*
 		touch /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_1
 		echo "$(date "+%d.%m.%Y %T") INFO: Final counter used - resetting loop and created counter_1."
 	else
-		rm /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_$CounterNumber
+		rm /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_*
 		CounterNumber=$((CounterNumber+1))
 		touch /mnt/user/appdata/other/rclone/remotes/$RcloneUploadRemoteName/counter_$CounterNumber
 		echo "$(date "+%d.%m.%Y %T") INFO: Created counter_${CounterNumber} for next upload run."


### PR DESCRIPTION

While running my upload script every 15m, some instances occurred where the counter would be recreated (unsure if it was issue with reading the initial count or editing/deleting the count file after finishing). After running for 24hrs I had 4 counters in total (counter_1, counter_2, counter_11, counter_100).

Having the multiple counters would cause the script to pick a random counter_x to set the count number to, or on other occasions, error out with an unreadable value causing a new counter to be created (counter_1) adding yet another counter file folder.  

Changed script with wildcard to simply clear out all counters prior to placing new counter_$CounterNumber.

![counters](https://user-images.githubusercontent.com/1813230/74989485-76586000-540e-11ea-8ff4-3349d04d96af.png)