### PR TITLE
Skip MergerFS folder creation on 'ignore'

### DIFF
--- a/rclone_mount
+++ b/rclone_mount
@@ -66,7 +66,14 @@ else
 	eval mkdir -p $LocalFilesLocation/"$MountFolders"
 fi
 mkdir -p $RcloneMountLocation
-mkdir -p $MergerFSMountLocation
+
+if [[  $MergerfsMountShare == 'ignore' ]]; then
+	echo "$(date "+%d.%m.%Y %T") INFO: Not creating MergerFS folders as requested."
+else
+	echo "$(date "+%d.%m.%Y %T") INFO: Creating MergerFS folders."
+	mkdir -p $MergerFSMountLocation
+fi
+
 
 #######  Check if script is already running  #######
 echo "$(date "+%d.%m.%Y %T") INFO: *** Starting mount of remote ${RcloneRemoteName}"


### PR DESCRIPTION
Current script creates a MergerFS folder of 'ignore' when ignore flag is set, adding check on creation to skip if  MergerFS folders if set to ignore